### PR TITLE
Fix deployment to

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,22 +21,46 @@ jobs:
       run: |
         ssh -o StrictHostKeyChecking=no -i key.pem ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }} "
           cd blog-flask-webapp
+
+          # BACKUP CURRENT DATABASE FIRST (prevent data loss!)
+          if [ -f instance/blog.db ]; then
+            echo 'Backing up current database before deployment...'
+            BACKUP_NAME=blog_pre_deploy_\$(date +%Y%m%d_%H%M%S).db
+            cp instance/blog.db instance/\$BACKUP_NAME
+            aws s3 cp instance/\$BACKUP_NAME s3://${{ secrets.S3_BACKUP_BUCKET }}/blog_backups/\$BACKUP_NAME || echo 'S3 backup failed, continuing with local backup'
+            echo 'Pre-deployment backup complete!'
+          fi
+
           sudo git pull origin main
-          
-          # RESTORE DATABASE FROM S3
-          echo 'Restoring database from S3...'
-          aws s3 cp s3://christina-blog-backups-1ee49a27/blog_backups/\$(aws s3 ls s3://christina-blog-backups-1ee49a27/blog_backups/ | sort | tail -n 1 | awk '{print \$4}') instance/blog.db
-          echo 'Database restored!'
-          
+
+          # Only restore from S3 if database doesn't exist or is empty
+          if [ ! -f instance/blog.db ] || [ ! -s instance/blog.db ]; then
+            echo 'No local database found, restoring from S3...'
+            LATEST=\$(aws s3 ls s3://${{ secrets.S3_BACKUP_BUCKET }}/blog_backups/ | sort | tail -n 1 | awk '{print \$4}')
+            if [ ! -z \"\$LATEST\" ]; then
+              aws s3 cp s3://${{ secrets.S3_BACKUP_BUCKET }}/blog_backups/\$LATEST instance/blog.db
+              echo 'Database restored from S3!'
+            else
+              echo 'No S3 backup found, will use fresh database'
+            fi
+          else
+            echo 'Existing database found, keeping current data'
+          fi
+
           # Start app
           sudo pkill gunicorn || true
-          cd blog-flask-webapp
-          sudo nohup gunicorn -w 1 -b 0.0.0.0:5000 run:app > /tmp/app.log 2>&1 &
+          source venv/bin/activate 2>/dev/null || true
+          nohup gunicorn -w 1 -b 0.0.0.0:5000 run:app > /tmp/app.log 2>&1 &
           sleep 5
           if pgrep gunicorn > /dev/null; then
             echo 'Deployment successful!'
           else
             echo 'Deployment failed!'
+            cat /tmp/app.log
             exit 1
           fi
         "
+
+
+
+

--- a/app/templates/admin/dashboard.html
+++ b/app/templates/admin/dashboard.html
@@ -149,14 +149,18 @@
                             </td>
                             <td>
                                 <div class="btn-group btn-group-sm" role="group">
-                                    <a href="{{ url_for('admin.edit_post', id=post.id) }}" 
-                                       class="btn btn-outline-primary">
+                                    <a href="{{ url_for('admin.edit_post', id=post.id) }}"
+                                       class="btn btn-outline-primary" title="Edit">
                                         <i class="bi bi-pencil"></i>
                                     </a>
-                                    <a href="{{ url_for('main.post', slug=post.slug) }}" 
-                                       target="_blank" class="btn btn-outline-info">
+                                    <a href="{{ url_for('main.post', slug=post.slug) }}"
+                                       target="_blank" class="btn btn-outline-info" title="View">
                                         <i class="bi bi-eye"></i>
                                     </a>
+                                    <button type="button" class="btn btn-outline-danger"
+                                            onclick="confirmDelete({{ post.id }}, '{{ post.title }}')" title="Delete">
+                                        <i class="bi bi-trash"></i>
+                                    </button>
                                 </div>
                             </td>
                         </tr>
@@ -175,6 +179,41 @@
         {% endif %}
     </div>
 </div>
+
+<!-- Delete Confirmation Modal -->
+<div class="modal fade" id="deleteModal" tabindex="-1">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Confirm Delete</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <p>Are you sure you want to delete the post "<strong id="deletePostTitle"></strong>"?</p>
+                <p class="text-danger"><small>This action cannot be undone.</small></p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <form method="POST" id="deleteForm" style="display: inline;">
+                    <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+                    <button type="submit" class="btn btn-danger">Delete Post</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+function confirmDelete(postId, postTitle) {
+    document.getElementById('deletePostTitle').textContent = postTitle;
+    document.getElementById('deleteForm').action = `/admin/posts/${postId}/delete`;
+
+    const deleteModal = new bootstrap.Modal(document.getElementById('deleteModal'));
+    deleteModal.show();
+}
+</script>
 {% endblock %}
 
 


### PR DESCRIPTION
   preserve database and add delete button to dashboard

   - Backup database to S3 before deploying to prevent data loss
   - Only restore from S3 if database is missing (not on every deploy)
   - Use S3_BACKUP_BUCKET secret instead of hardcoded bucket name
   - Add delete button with confirmation modal to admin dashboard