### PR TITLE
Use dynamic EC2 IP lookup instead of static host

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,19 +7,36 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-      
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ secrets.AWS_REGION }}
+
+    - name: Get EC2 instance IP
+      id: get-ip
+      run: |
+        EC2_IP=$(aws ec2 describe-instances \
+          --filters "Name=tag:Name,Values=ChristinaKneisWebsite" "Name=instance-state-name,Values=running" \
+          --query 'Reservations[0].Instances[0].PublicIpAddress' \
+          --output text)
+        echo "EC2_IP=$EC2_IP" >> $GITHUB_OUTPUT
+        echo "Found EC2 IP: $EC2_IP"
+
     - name: Add SSH key
       run: |
         echo "${{ secrets.EC2_SSH_KEY }}" > key.pem
         chmod 600 key.pem
-        
+
     - name: Deploy to EC2
       run: |
-        ssh -o StrictHostKeyChecking=no -i key.pem ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }} "
+        ssh -o StrictHostKeyChecking=no -i key.pem ${{ secrets.EC2_USERNAME }}@${{ steps.get-ip.outputs.EC2_IP }} "
           cd blog-flask-webapp
 
           # BACKUP CURRENT DATABASE FIRST (prevent data loss!)


### PR DESCRIPTION
Workflow now queries AWS for the current EC2 instance IP using the instance tag, so deployments work even when ASG replaces instances.